### PR TITLE
PPU background maker

### DIFF
--- a/controller/Emulator.cpp
+++ b/controller/Emulator.cpp
@@ -6,7 +6,7 @@
 
 Emulator::Emulator(IScreen *screen, IControls *controls, const std::string& cartPath): screen(screen), controls(controls) {
     cpu = new CPU();
-    ppu = new PPU();
+
 
     cart = new Cartridge(cartPath);
     vRam = new VRAM();
@@ -17,6 +17,7 @@ Emulator::Emulator(IScreen *screen, IControls *controls, const std::string& cart
     lcd = new LCD(dma);
     io = new IO(lcd);
     bus = new Bus(cart, vRam, oamRam, hRam, wRam, dma, io);
+    ppu = new PPU(lcd, bus);
 
     targetCPUDotCount = cpu->getCycleCount();
 
@@ -25,7 +26,7 @@ Emulator::Emulator(IScreen *screen, IControls *controls, const std::string& cart
 
 void Emulator::runFrame() {
 //    cpu->tick(*bus);
-//    ppu->ppu_tick();
+//    ppu->tick();
     for (unsigned int r = 0; r < 144; r++) {
         ppuMode = OAM_SCAN;
         runForDots(80);
@@ -54,7 +55,7 @@ Emulator::~Emulator() {
 }
 
 void Emulator::runForDots(unsigned int dots) {
-//    ppu->ppu_tick();
+//    ppu->ppuTick();
     targetCPUDotCount += dots;
     while (cpu->getCycleCount() < targetCPUDotCount) {
         cpu->tick(*bus);

--- a/model/PPU/LCD.cpp
+++ b/model/PPU/LCD.cpp
@@ -16,6 +16,8 @@ LCD::LCD(DMA* dma) : dma(dma) {
     lcdRegs.winX = 0;
     lcdRegs.winY = 0;
 
+    setLcdMode(MODE_OAM);
+
     for (int i = 0; i < 4; i++) bgColors[i] = sp1Colors[i] = sp2Colors[i] = i;
 }
 
@@ -80,6 +82,22 @@ void LCD::updatePalette(uint8_t paletteData, uint8_t palette) {
         sp2Colors[0] = paletteData >> 4 & 0b11;
         sp2Colors[0] = paletteData >> 6 & 0b11;
     }
+}
+
+uint8_t LCD::getLy() {
+    return lcdRegs.ly;
+}
+
+void LCD::resetLy() {
+    lcdRegs.ly = 0;
+}
+
+uint8_t LCD::getScrollY() {
+    return lcdRegs.scrollY;
+}
+
+uint8_t LCD::getScrollX() {
+    return lcdRegs.scrollX;
 }
 
 

--- a/model/PPU/LCD.h
+++ b/model/PPU/LCD.h
@@ -41,6 +41,12 @@ private:
 public:
     LCD(DMA* dma);
 
+    void resetLy();
+    uint8_t getLy();
+    void incrementLy();
+
+    uint8_t getLyCompare();
+
     //Control register settings
     bool getBgWEnabled() const;
     bool getObjEnabled() const;
@@ -65,6 +71,10 @@ public:
     void write(uint16_t address, uint8_t value);
 
     void updatePalette(uint8_t paletteData, uint8_t palette);
+
+    uint8_t getScrollY();
+
+    uint8_t getScrollX();
 };
 
 

--- a/model/PPU/PPU.cpp
+++ b/model/PPU/PPU.cpp
@@ -4,10 +4,195 @@
 
 #include "PPU.h"
 
-PPU::PPU() {}
+PPU::PPU(LCD* lcd, Bus* bus) : lcd(lcd) {
+    currFrame = 0;
+    lineTicks = 0;
+    pipelineZeros();
 
-void PPU::ppu_tick() {};
+    display =  new char*[Y_RES];
+    for (int x = 0; x < Y_RES; x++)
+    {
+        display[x] = new char[X_RES];
+    }
+}
 
-char **PPU::debugTiles() {
-    return nullptr;
+void PPU::tick() {
+    lineTicks++;
+
+    switch(lcd->getLcdMode()) {
+        case MODE_OAM:
+            runOamMode();
+            break;
+        case MODE_XFER:
+            runXferMode();
+            break;
+        case MODE_VBLANK:
+            runVBlankMode();
+            break;
+        case MODE_HBLANK:
+            runHBlankMode();
+            break;
+    }
+};
+
+void PPU::runOamMode() {
+    if (lineTicks >= 80) {
+        lcd->setLcdMode(MODE_XFER);
+        pipelineZeros();
+    }
+}
+
+void PPU::runXferMode() {
+    pipelineProcess();
+    if (pushX >= X_RES) lcd->setLcdMode(MODE_HBLANK);
+}
+
+void PPU::runVBlankMode() {
+    if (lineTicks >= TICKS_PER_LINE) {
+        //Increment and check line count
+        handleLy();
+
+        if (lcd->getLy() >= LINES_PER_FRAME) {
+            lcd->setLcdMode(MODE_OAM);
+            lcd->resetLy();
+        }
+
+        lineTicks = 0;
+    }
+}
+
+void PPU::runHBlankMode() {
+    if (lineTicks >= TICKS_PER_LINE) {
+        //Increment and check line count
+        handleLy();
+
+        if (lcd->getLy() >= Y_RES) {
+            lcd->setLcdMode(MODE_VBLANK);
+
+            //TODO send VBLANK interrupt
+            if (lcd->getVBlankInt()) {
+                //TODO send STAT interrupt
+            }
+
+            currFrame++;
+        } else {
+            lcd->setLcdMode(MODE_OAM);
+        }
+        //TODO send display to UI
+        lineTicks = 0;
+    }
+}
+
+void PPU::handleLy() {
+    lcd->incrementLy();
+    if (lcd->getLy() == lcd->getLyCompare()) {
+        lcd->setLycFlag(true);
+        lcd->resetLy();
+
+        if (lcd->getLycInt()) {
+            //TODO send STAT interrupt
+        }
+
+    } else {
+        lcd->setLycFlag(false);
+    }
+}
+
+void PPU::fifoPush(uint8_t value) {
+    fifo.push_back(value);
+}
+
+uint8_t PPU::fifoPop() {
+    uint8_t returnValue = fifo.front();
+    fifo.pop_front();
+    return returnValue;
+}
+
+void PPU::pipelineZeros() {
+    fetchState = TILE;
+    lineX = 0;
+    fetchX = 0;
+    pushX = 0;
+    fifoX = 0;
+}
+
+void PPU::pipelineProcess() {
+    mapY = lcd->getLy() + lcd->getScrollY();
+    mapX = fetchX + lcd->getScrollX();
+    tileY = ((lcd->getLy() + lcd->getScrollY()) % 8) * 2;
+
+    //Every other line
+    if (!(lineTicks % 2)) {
+        fetchPixel();
+    }
+    pushPixel();
+}
+
+void PPU ::pushPixel() {
+    if (fifo.size() > 8) {
+        uint8_t pixel = fifoPop();
+
+        if (lineX >= (lcd->getScrollX() % 8)) {
+            display[lcd->getLy()][pushX] = pixel;
+            pushX++;
+        }
+
+        lineX++;
+    }
+}
+
+void PPU::fetchPixel() {
+    switch (fetchState) {
+        case TILE:
+            if (lcd->getBgWEnabled()) {
+                bgwFetchData[0] = bus->read(lcd->getBgMapArea() + (mapX / 8) + ((mapY / 8) * 32));
+
+                if (lcd->getBgWDataArea() == 0x8800) {
+                    bgwFetchData[0] += 128;
+                }
+
+                fetchX += 8;
+                fetchState = DATA0;
+            }
+            break;
+        case DATA0:
+            bgwFetchData[1] = bus->read(lcd->getBgWDataArea() + bgwFetchData[0] * 16 + tileY);
+            fetchState = DATA1;
+            break;
+        case DATA1:
+            bgwFetchData[2] = bus->read(lcd->getBgWDataArea() + bgwFetchData[0] * 16 + tileY + 1);
+            fetchState = SLEEP;
+            break;
+        case SLEEP:
+            fetchState = PUSH;
+            break;
+        case PUSH:
+            if (pipelineAdd()) {
+                fetchState = TILE;
+            }
+            break;
+    }
+}
+
+bool PPU::pipelineAdd() {
+    if (fifo.size() > 8) return false;
+    int x = fetchX - (8 - lcd->getScrollX() % 8);
+
+    //Calculate pixel intensity
+    for (int bit = 7; bit >= 0; bit--) {
+        uint8_t low = ((bgwFetchData[1] & (1 << bit)) != 0);
+        uint8_t high = ((bgwFetchData[2] & (1 << bit)) != 0) << 1;
+        uint8_t pixel = high | low;
+
+        if (x >= 0) {
+            fifoPush(pixel);
+            fifoX++;
+        }
+    }
+
+    return true;
+}
+
+void PPU::pipelineReset() {
+    while (fifo.size() > 0) fifo.pop_front();
 }

--- a/model/PPU/PPU.h
+++ b/model/PPU/PPU.h
@@ -2,22 +2,76 @@
 // Created by Tyson Peterson on 2/26/24.
 //
 
-#include <string>
-#include <cstdint>
-#include <fstream>
-#include <iostream>
+
 
 #ifndef GAMEBOY_EMULATOR_PPU_H
 #define GAMEBOY_EMULATOR_PPU_H
 
+#include <string>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <deque>
+#include "LCD.h"
+#include "../Memory/Bus.h"
+
+static const int LINES_PER_FRAME = 154;
+static const int TICKS_PER_LINE = 456;
+static const int Y_RES = 144;
+static const int X_RES = 160 ;
+
+enum FetchState {
+    TILE,
+    DATA0,
+    DATA1,
+    SLEEP,
+    PUSH
+};
+
 class PPU {
 private:
+    uint32_t currFrame;
+    uint32_t lineTicks;
+
+    char** display;
+
+    LCD* lcd;
+    Bus* bus;
+
+    //Pipeline Stuff
+    FetchState fetchState;
+    uint8_t lineX;
+    uint8_t pushX;
+    uint8_t fetchX;
+    uint8_t bgwFetchData[3];
+    uint8_t fetchEntryData[6];
+    uint8_t mapY;
+    uint8_t mapX;
+    uint8_t tileY;
+    uint8_t fifoX;
+
+    std::deque<uint8_t> fifo;
+
+    void runOamMode();
+    void runXferMode();
+    void runVBlankMode();
+    void runHBlankMode();
+
+    void handleLy();
+
+    void fifoPush(uint8_t value);
+    uint8_t fifoPop();
+
+    void pipelineZeros();
+    void pipelineProcess();
+    bool pipelineAdd();
+    void pipelineReset();
+    void pushPixel();
+    void fetchPixel();
 
 public:
-    PPU();
-    void ppu_tick();
-
-    char** debugTiles();
+    PPU(LCD* lcd, Bus* bus);
+    void tick();
 };
 
 


### PR DESCRIPTION
This should render the background. Do I have any idea if it actually works? Nope.

I am handling the PPU states in the class, it makes a little more sense for me to do that since the timing can be dynamic.

I need a way to get the display char** back down to the emulator. We can use a pull observer and have the emulator poll the PPU every few cycles or the PPU can notify the emulator when the frame is ready. Anything works.

It also needs to interface with interrupts, so just let me know when that's done.